### PR TITLE
Updating base, terraform, adding tfsec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,26 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
-ENV TF_1_VERSION=1.1.7
-ENV TERRAFORM_LINT_VERSION=0.35.0
+ENV TF_1_VERSION=1.2.2
+ENV TERRAFORM_LINT_VERSION=0.37.0
 ENV TERRAFORM_DOCS_VERSION=0.16.0
-ENV TERRAGRUNT_VERSION=0.36.6
-ENV INFRACOST_VERSION=0.9.20
+ENV TERRAGRUNT_VERSION=0.37.3
+ENV INFRACOST_VERSION=0.10.3
 ENV KBENV_VERSION=0.3.1
 ENV KUBECTL_121_VERSION=1.21.11
-ENV KUBECTL_122_VERSION=1.22.7
+ENV KUBECTL_122_VERSION=1.22.10
 ENV HELMENV_VERSION=0.3.1
-ENV HELM_VERSION=3.7.2
+ENV HELM_VERSION=3.9.0
+ENV TFSEC_VERSION=1.24.0
 
 WORKDIR /bin
 
 RUN apk update && \
     apk add --no-cache \
-    bash=5.1.16-r0 \
-    curl=7.80.0-r0 \
-    git=2.34.1-r0 \
-    perl-utils=5.34.0-r1 \
-    wget=1.21.2-r2 \
+    bash=5.1.16-r2 \
+    curl=7.83.1-r1 \
+    git=2.36.1-r0 \
+    perl-utils=5.34.1-r0 \
+    wget=1.21.3-r0 \
     unzip=6.0-r9 \
     tar=1.34-r0 \
     && \
@@ -32,6 +33,8 @@ RUN apk update && \
     wget -qO infracost-linux-amd64.tar.gz https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}/infracost-linux-amd64.tar.gz && \
     wget -qO kbenv-linux-amd64.tar.gz https://github.com/little-angry-clouds/kubernetes-binaries-managers/releases/download/${KBENV_VERSION}/kbenv-linux-amd64.tar.gz && \
     wget -qO helmenv-linux-amd64.tar.gz https://github.com/little-angry-clouds/kubernetes-binaries-managers/releases/download/${HELMENV_VERSION}/helmenv-linux-amd64.tar.gz && \
+    wget -qO tfsec https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64 && \
+    wget -qO tfsec-checkgen https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-checkgen-linux-amd64 && \
     tar -xzf terraform-docs.tar.gz && \
     tar xzf infracost-linux-amd64.tar.gz && \
     tar xzf kbenv-linux-amd64.tar.gz && \
@@ -47,7 +50,7 @@ RUN apk update && \
     rm infracost-linux-amd64.tar.gz && \
     rm kbenv-linux-amd64.tar.gz && \
     rm helmenv-linux-amd64.tar.gz && \
-    chmod +x terraform-docs tflint terragrunt infracost kbenv kubectl helmenv helm && \
+    chmod +x terraform-docs tflint terragrunt infracost kbenv kubectl helmenv helm tfsec tfsec-checkgen && \
     . ~/.bashrc && \
     apk del \
     git \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ TAG := latest
 GIT_TAG = $(shell git describe --tags $(git rev-list --tags --max-count=1) | sed s/v//g)
 PACKAGE_VERSION = $(shell cat package.json| jq -r '.version')
 IMAGE_TAG := ${DOCKER_REGISTRY_URL}/library/tf-tools
+PACKAGE_VERSION = $(shell cat package.json| jq -r '.version')
+NEXT_VERSION=$(shell echo ${PACKAGE_VERSION} | awk -F. -v OFS=. '{$$NF += 1 ; print}')
 
 build: ## Build the docker container and tag as latest
 	docker build -t ${IMAGE_TAG}:${TAG} .
@@ -38,6 +40,15 @@ check-version: ## Checks for the required version bump
 	fi
 	@echo "\033[36m"Version Check Complete"\033[0m"
 .PHONY: check-version
+
+bump-version: ## bump minor version
+	@echo "Current version in repo is \033[0;31m${PACKAGE_VERSION}\033[0m"; \
+	echo "New version will be \033[0;32m${NEXT_VERSION}\033[0m"; \
+	jq '.version = "${NEXT_VERSION}"' package.json > tmp_package.json; \
+	rm package.json; \
+	mv tmp_package.json package.json; \
+	echo "Version now set to \033[36m${NEXT_VERSION}\033[0m"
+.PHONY: bump-version
 
 prepare-pr: hadolint build grype check-version ## Runs grype, and hadolint to check for issues with container before your PR
 	@echo "\033[36m"Done Running PR Checks"\033[0m"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Kubernetescli (managed by kbenv above)
 
 Infracost for generating cross-cloud pricing (<https://github.com/infracost>)
 
+TFSec For writing policy as code checks (https://github.com/aquasecurity/tfsec)
+
 This container gets used locally, and in CI to make sure all build processes use same environment setup.
 
 ### How to work with the repo
@@ -45,9 +47,10 @@ Targets:
   tag         Tag the docker image
   grype       Runs grype locally - you need to have it installed first (https://github.com/anchore/grype)
   hadolint    Runs hadolint locally - you need to have it installed first (https://github.com/hadolint/hadolint)
+  check-version  Checks for the required version bump
+  bump-version  bump minor version
   prepare-pr  Runs grype, and hadolint to check for issues with container before your PR
   help        show this usage
-  
 ```
 
 ### PR Checks and Github Actions

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "tf-tools",
-    "version": "1.0.4"
+  "name": "tf-tools",
+  "version": "1.0.5"
 }


### PR DESCRIPTION
Updating base Alpine image to 3.16
Updating pre-installed Terraform to 1.2.2
Updating Terraform lint to 0.37.0
Updating Terragrunt to 0.37.3
Updating Infracost to 0.10.3
Updating Kubectl 1.22 to 1.22.10
Updating Helm version to 3.9.0
Adding TFSec to do policy checks and best practices.

Adding make bump-version command to make file